### PR TITLE
Correção de conflito com outros módulos de pagamento

### DIFF
--- a/Model/Boleto/ConfigProvider.php
+++ b/Model/Boleto/ConfigProvider.php
@@ -50,20 +50,26 @@ class ConfigProvider extends CcGenericConfigProvider
      */
     public function getConfig()
     {
-        $config = parent::getConfig();
+        $method = $this->_boletoHelper->getMethodCode();
 
-        if ($this->_boletoHelper->getConfigData('active')) {
-            $checkoutImageAsset = $this->_assetRepo->createAsset('Gabrielqs_Boleto::images/checkout.png');
-            $config['payment'][$this->_boletoHelper->getMethodCode()] = [
-                'active'               => true,
-                'checkout_image'           => $checkoutImageAsset->getUrl()
-            ];
-        } else {
-            $config['payment'][$this->_boletoHelper->getMethodCode()] = [
-                'active'                                  => false,
+        if (!$this->_boletoHelper->getConfigData('active')) {
+            return [
+                'payment' => [
+                    $method => [
+                        'active' => false,
+                    ]
+                ]
             ];
         }
 
-        return $config;
+        $checkoutImageAsset = $this->_assetRepo->createAsset('Gabrielqs_Boleto::images/checkout.png');
+        return [
+            'payment' => [
+                $method => [
+                    'active'         => true,
+                    'checkout_image' => $checkoutImageAsset->getUrl()
+                ]
+            ]
+        ];
     }
 }


### PR DESCRIPTION
Nesta alteração foi corrigido um conflito deste módulo com outros módulos de pagamento, estou usando o mercado pago como exemplo, pois neste módulo ele chamava o getConfig do parent, assim causando duplicação dos meses/ano da data de validade do cartão de crédito, após essa correção, este erro parou de acontecer em todos os módulos de pagamento que eu utilizo na loja.

Evidência:
![meses repetidos](https://user-images.githubusercontent.com/2152861/29477755-2549c0f0-8440-11e7-89de-681343b91803.png)